### PR TITLE
Fix ESLint warning @microsoft/sdl/no-html-method

### DIFF
--- a/frontend/js/init.js
+++ b/frontend/js/init.js
@@ -166,7 +166,7 @@
             // There was an error
             else {
                $('#image-loader').fadeOut();
-               $('#message-warning').html(msg);
+               $('#message-warning').text(msg);
 	            $('#message-warning').fadeIn();
             }
 


### PR DESCRIPTION
Replaces insecure `.html()` call with `.text()` to resolve ESLint warning in `frontend/js/init.js`.

---
*PR created automatically by Jules for task [14783038452008636311](https://jules.google.com/task/14783038452008636311) started by @davisdre*