### PR TITLE
Refactor CI/CD from Gitea Actions to GitHub Actions

### DIFF
--- a/.github/workflows/backend.main.yml
+++ b/.github/workflows/backend.main.yml
@@ -36,7 +36,9 @@ jobs:
     - name: 'Login via Azure CLI'
       uses: azure/login@v2
       with:
-          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CREDENTIALS }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: 'Get Function App name from deployment output'
       id: get-functionapp

--- a/.github/workflows/frontend.main.yml
+++ b/.github/workflows/frontend.main.yml
@@ -31,7 +31,9 @@ jobs:
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash || curl -sL https://aka.ms/InstallAzureCLIDeb | bash
     - uses: azure/login@v2
       with:
-          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CREDENTIALS }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: 'Resolve deployment outputs (storage + function URL)'
       id: get-outputs

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -35,7 +35,9 @@ jobs:
       - name: 'Login via Azure CLI'
         uses: azure/login@v2
         with:
-            creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CREDENTIALS }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy Infrastructure
         run: |


### PR DESCRIPTION
Moved workflow files from `.gitea/workflows` to `.github/workflows`. Updated all `paths` properties to reflect the new paths. Updated workflow names from "Gitea Actions" to "GitHub Actions". Updated azure/login@v2 to use OIDC instead of creds.