### PR TITLE
fix: enforce FTPS only for Function App

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -102,6 +102,7 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
     serverFarmId: appServicePlan.id
     httpsOnly: true
     siteConfig: {
+      ftpsState: 'FtpsOnly'
       netFrameworkVersion: 'v8.0' // Explicitly set .NET 8
       use32BitWorkerProcess: false // Run as a 64-bit process for .NET Isolated
       cors: {


### PR DESCRIPTION
Enable FTPS enforcement for enhanced security on the Azure Function App to resolve TA-000009.

---
*PR created automatically by Jules for task [818022145149325260](https://jules.google.com/task/818022145149325260) started by @davisdre*