### PR TITLE
Fix: Enforce TLS 1.2 for Function App

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -102,6 +102,7 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
     serverFarmId: appServicePlan.id
     httpsOnly: true
     siteConfig: {
+      minTlsVersion: '1.2'
       ftpsState: 'FtpsOnly'
       netFrameworkVersion: 'v8.0' // Explicitly set .NET 8
       use32BitWorkerProcess: false // Run as a 64-bit process for .NET Isolated


### PR DESCRIPTION
Added `minTlsVersion: '1.2'` to the siteConfig block of the Function App resource in `infra/main.bicep` to remediate the "Latest TLS version should be used in your function app" security alert.

---
*PR created automatically by Jules for task [1945679111555497769](https://jules.google.com/task/1945679111555497769) started by @davisdre*