### PR TITLE
Fix Azure.Storage.Firewall PSRule alert

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,6 +31,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
     supportsHttpsTrafficOnly: true
     allowBlobPublicAccess: false // Hardened: Disabling public access (Resolves #23)
     allowSharedKeyAccess: false // Hardened: Disabling account key-based access
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
   }
 }
 


### PR DESCRIPTION
Set default network access rule to 'Deny' on the main storage account in the bicep template in order to remediate a DevOps security alert.

---
*PR created automatically by Jules for task [1162404864304269121](https://jules.google.com/task/1162404864304269121) started by @davisdre*