### PR TITLE
Fix Chrome DevTools deprecation warning for persistentStorage

### DIFF
--- a/frontend/js/modernizr-custom.js
+++ b/frontend/js/modernizr-custom.js
@@ -9118,6 +9118,9 @@ Detects the ability to request a specific amount of space for filesystem access
 */
 
   Modernizr.addTest('quotamanagement', function() {
+    if ('storage' in navigator && navigator.storage.estimate) {
+      return true;
+    }
     var tempStorage = prefixed('temporaryStorage', navigator);
     var persStorage = prefixed('persistentStorage', navigator);
 


### PR DESCRIPTION
Modified the `quotamanagement` test in `frontend/js/modernizr-custom.js` to check for the standardized `navigator.storage` API before attempting to access legacy prefixed storage properties. This prevents Chrome from logging the deprecation warning for `StorageType.persistent` while preserving functionality.

---
*PR created automatically by Jules for task [216266154941660241](https://jules.google.com/task/216266154941660241) started by @davisdre*